### PR TITLE
Fix 2021.2 compatibility issue

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,7 +31,8 @@
   <extensions defaultExtensionNs="com.intellij">
 
     <!-- Language support -->
-    <fileTypeFactory implementation="org.p4.p4plugin.P4LangFileType$Factory" />
+    <fileType name="P4 Language" implementationClass="org.p4.p4plugin.P4LangFileType"
+              fieldName="INSTANCE" language="P4Lang" extensions="p4"/>
     <lang.commenter language="P4Lang"
                     implementationClass="org.p4.p4plugin.P4Commenter" />
     <completion.contributor language="P4Lang" implementationClass="org.p4.p4plugin.completion.P4LangKeywordCompletionContributor"/>


### PR DESCRIPTION
- fileTypeFactory -> fileType

This change is required to build the plugin with ideaVersion=2021.2. fileTypeFactory is deprecated. Details on the change can be found here: https://plugins.jetbrains.com/docs/intellij/language-and-filetype.html#register-the-filetype)