### PR TITLE
Preprocessor multiline fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 pluginVersion=1.0
-ideaVersion=2020.2
+ideaVersion=2021.3
 antlr4Version=4.9

--- a/src/main/antlr/P4.g4
+++ b/src/main/antlr/P4.g4
@@ -935,7 +935,7 @@ PREPROC_INCLUDE_SYS         : '#include' [ ]*? '<' ~[\n|\r]+ '>' -> channel(HIDD
 // The wise StackOverflow oracle suggested this:
 // https://stackoverflow.com/questions/48320194/antlr-parsing-multiline-define-for-c-g4
 //PREPROC_DEFINE              : '#' (~['\\'\r\n] | '\\' [ \t]* EOL )* -> channel(HIDDEN);
-PREPROC_DEFINE              : '#define ' (~[\\\r\n] | '\\' [\r]?'\n' | '\\'. )* -> channel(HIDDEN);
+PREPROC_DEFINE              : '#' (~[\\\r\n] | '\\' [\r]?'\n' | '\\'. )* -> channel(HIDDEN);
 //PREPROC_DEFINE              : '#define ' (~[\r\n])+ -> channel(HIDDEN);
 PREPROC_UNDEF		        : '#undef ' ~[\n|\r]+ -> channel(HIDDEN);
 PREPROC_IFDEF			    : '#ifdef ' ~[\n|\r]+ -> channel(HIDDEN);

--- a/src/main/antlr/P4.g4
+++ b/src/main/antlr/P4.g4
@@ -924,19 +924,24 @@ WS 							: [ \t\r\n]+ -> channel(HIDDEN) ;
 COMMENT 					: '/*' .*? '*/' -> channel(HIDDEN) ;
 LINE_COMMENT 				: '//' ~[\r\n]* -> channel(HIDDEN) ;
 fragment ESCAPED_QUOTE 		: '\\"';
+fragment EOL                : '\r'? '\n';
 STRING_LITERAL 				: '"' ( ESCAPED_QUOTE | ~('\n'|'\r') )*? '"';
 
 // All preprocessor statements will be ignored in the lexer and the parser
 //PREPROCESSSOR             : '#' ~[\r\n]* -> channel(HIDDEN);
 PREPROC_INCLUDE_LOCAL   	: '#include' [ ]*? STRING_LITERAL -> channel(HIDDEN);
 PREPROC_INCLUDE_SYS         : '#include' [ ]*? '<' ~[\n|\r]+ '>' -> channel(HIDDEN);
-PREPROC_DEFINE			    : '#define ' ~[\n|\r]+ -> channel(HIDDEN);
+//PREPROC_DEFINE			    : '#define ' ~[\n|\r]+ -> channel(HIDDEN);
+// The wise StackOverflow oracle suggested this:
+// https://stackoverflow.com/questions/48320194/antlr-parsing-multiline-define-for-c-g4
+//PREPROC_DEFINE              : '#' (~['\\'\r\n] | '\\' [ \t]* EOL )* -> channel(HIDDEN);
+PREPROC_DEFINE              : '#define ' (~[\\\r\n] | '\\' [\r]?'\n' | '\\'. )* -> channel(HIDDEN);
+//PREPROC_DEFINE              : '#define ' (~[\r\n])+ -> channel(HIDDEN);
 PREPROC_UNDEF		        : '#undef ' ~[\n|\r]+ -> channel(HIDDEN);
 PREPROC_IFDEF			    : '#ifdef ' ~[\n|\r]+ -> channel(HIDDEN);
 PREPROC_IFNDEF			    : '#ifndef ' ~[\n|\r]+ -> channel(HIDDEN);
 PREPROC_LINE			    : '#line ' [0-9]+ STRING_LITERAL [0-9]*? -> channel(HIDDEN);
 PREPROC_IF				    : '#if ' ~[\n|\r]+ -> channel(HIDDEN);
-PREPROC_ELSEIF			    : '#elseif ' ~[\n|\r]+ -> channel(HIDDEN);
 PREPROC_ELIF			    : '#elif ' ~[\n|\r]+ -> channel(HIDDEN);
 PREPROC_ENDIF			    : '#endif' -> channel(HIDDEN);
 PREPROC_ELSE				: '#else' -> channel(HIDDEN);

--- a/src/main/antlr/P4.g4
+++ b/src/main/antlr/P4.g4
@@ -928,23 +928,11 @@ fragment EOL                : '\r'? '\n';
 STRING_LITERAL 				: '"' ( ESCAPED_QUOTE | ~('\n'|'\r') )*? '"';
 
 // All preprocessor statements will be ignored in the lexer and the parser
-//PREPROCESSSOR             : '#' ~[\r\n]* -> channel(HIDDEN);
 PREPROC_INCLUDE_LOCAL   	: '#include' [ ]*? STRING_LITERAL -> channel(HIDDEN);
 PREPROC_INCLUDE_SYS         : '#include' [ ]*? '<' ~[\n|\r]+ '>' -> channel(HIDDEN);
-//PREPROC_DEFINE			    : '#define ' ~[\n|\r]+ -> channel(HIDDEN);
 // The wise StackOverflow oracle suggested this:
 // https://stackoverflow.com/questions/48320194/antlr-parsing-multiline-define-for-c-g4
-//PREPROC_DEFINE              : '#' (~['\\'\r\n] | '\\' [ \t]* EOL )* -> channel(HIDDEN);
 PREPROC_DEFINE              : '#' (~[\\\r\n] | '\\' [\r]?'\n' | '\\'. )* -> channel(HIDDEN);
-//PREPROC_DEFINE              : '#define ' (~[\r\n])+ -> channel(HIDDEN);
-PREPROC_UNDEF		        : '#undef ' ~[\n|\r]+ -> channel(HIDDEN);
-PREPROC_IFDEF			    : '#ifdef ' ~[\n|\r]+ -> channel(HIDDEN);
-PREPROC_IFNDEF			    : '#ifndef ' ~[\n|\r]+ -> channel(HIDDEN);
-PREPROC_LINE			    : '#line ' [0-9]+ STRING_LITERAL [0-9]*? -> channel(HIDDEN);
-PREPROC_IF				    : '#if ' ~[\n|\r]+ -> channel(HIDDEN);
-PREPROC_ELIF			    : '#elif ' ~[\n|\r]+ -> channel(HIDDEN);
-PREPROC_ENDIF			    : '#endif' -> channel(HIDDEN);
-PREPROC_ELSE				: '#else' -> channel(HIDDEN);
 
 IDENTIFIER					: [A-Za-z_][A-Za-z0-9_]*;
 TYPE_IDENTIFIER				: [A-Za-z_][A-Za-z0-9_]*;

--- a/src/main/java/org/p4/p4plugin/psi/P4ParserDefinition.java
+++ b/src/main/java/org/p4/p4plugin/psi/P4ParserDefinition.java
@@ -70,15 +70,7 @@ public class P4ParserDefinition implements ParserDefinition {
                 P4LangTokenType.getTokenElementType(P4Lexer.LINE_COMMENT),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_INCLUDE_LOCAL),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_INCLUDE_SYS),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_DEFINE),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_UNDEF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_IFDEF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_IFNDEF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_LINE),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_IF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ELIF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ENDIF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ELSE));
+                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_DEFINE));
     }
 
     @Override

--- a/src/main/java/org/p4/p4plugin/psi/P4ParserDefinition.java
+++ b/src/main/java/org/p4/p4plugin/psi/P4ParserDefinition.java
@@ -76,7 +76,6 @@ public class P4ParserDefinition implements ParserDefinition {
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_IFNDEF),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_LINE),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_IF),
-                P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ELSEIF),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ELIF),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ENDIF),
                 P4LangTokenType.getTokenElementType(P4Lexer.PREPROC_ELSE));

--- a/src/main/resources/demo/demo.p4
+++ b/src/main/resources/demo/demo.p4
@@ -23,6 +23,19 @@
 typedef bit<9> port_t;
 typedef bit<16> next_hop_id_t;
 
+/*
+#elif defined(ABCDEFGHIJKLMNOPQRS)
+const bit<32> abc = 1;
+#endif
+*/
+
+#define  TEST(param1) \
+    state ctrl_##param1 { \
+}
+
+#define
+#define test=1
+
 const port_t CPU_PORT = 255;
 
 struct local_metadata_t {

--- a/src/main/resources/demo/demo_preprocessor.p4
+++ b/src/main/resources/demo/demo_preprocessor.p4
@@ -1,7 +1,0 @@
-
-#define  TEST(param1)\
-    state ctrl_##param1 {\
-}
-
-control test() {
-}

--- a/src/main/resources/demo/demo_preprocessor.p4
+++ b/src/main/resources/demo/demo_preprocessor.p4
@@ -1,0 +1,7 @@
+
+#define  TEST(param1)\
+    state ctrl_##param1 {\
+}
+
+control test() {
+}


### PR DESCRIPTION
The existing lexer does fail on multi-line preprocessor statements. The PR fixes these and works for the existing examples. The two include statements seem still to be required, I am not sure why.